### PR TITLE
Encode Conn. Gen. Stat. § 19a-754c (Covered Connecticut premium subsidy)

### DIFF
--- a/.axiom/index/provisions_to_rules.json
+++ b/.axiom/index/provisions_to_rules.json
@@ -16637,6 +16637,15 @@
         ]
       }
     ],
+    "us-ct/statute/19a-754c": [
+      {
+        "module": "us-ct/statutes/19a-754c.yaml",
+        "via": [
+          "module",
+          "proof_atom"
+        ]
+      }
+    ],
     "us-ct/statute/2026-supplement/12-704e/earned-income-tax-credit": [
       {
         "module": "us-ct/policies/income_tax/2026_resident_liability_source_hold.yaml",

--- a/us-ct/statutes/19a-754c.test.yaml
+++ b/us-ct/statutes/19a-754c.test.yaml
@@ -1,0 +1,112 @@
+- name: eligible_adult_receives_residual_premium_subsidy
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 40
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.5
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 460
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_income_eligible: true
+    us-ct:statutes/19a-754c#covered_connecticut_adult_eligible: true
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 40
+- name: federal_subsidy_already_covers_full_premium
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 40
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.4
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 500
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 0
+- name: federal_subsidy_exceeding_premium_floors_at_zero
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 40
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.4
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 520
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 0
+- name: income_at_exactly_one_hundred_seventy_five_per_cent_is_eligible
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 55
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.75
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 600
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 480
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_income_eligible: true
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 120
+- name: income_above_one_hundred_seventy_five_per_cent_is_ineligible
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 40
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.76
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 400
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_income_eligible: false
+    us-ct:statutes/19a-754c#covered_connecticut_adult_eligible: false
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 0
+- name: adult_below_age_nineteen_is_outside_the_adult_cohort
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 18
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.5
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 400
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_adult_eligible: false
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 0
+- name: adult_above_age_sixty_four_is_outside_the_adult_cohort
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 65
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.5
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: true
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 400
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_adult_eligible: false
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 0
+- name: non_silver_enrollment_is_ineligible
+  period: 2026-01
+  input:
+    us-ct:statutes/19a-754c#input.adult_age: 40
+    us-ct:statutes/19a-754c#input.household_income_poverty_line_ratio: 1.5
+    us-ct:statutes/19a-754c#input.eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies: true
+    us-ct:statutes/19a-754c#input.ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits: true
+    us-ct:statutes/19a-754c#input.receiving_silver_level_exchange_individual_market_coverage: false
+    us-ct:statutes/19a-754c#input.utilizing_full_amount_of_applicable_premium_subsidies: true
+    us-ct:statutes/19a-754c#input.silver_level_qualified_health_plan_monthly_premium: 500
+    us-ct:statutes/19a-754c#input.federal_monthly_premium_subsidy: 400
+  output:
+    us-ct:statutes/19a-754c#covered_connecticut_adult_eligible: false
+    us-ct:statutes/19a-754c#covered_connecticut_monthly_premium_subsidy: 0

--- a/us-ct/statutes/19a-754c.yaml
+++ b/us-ct/statutes/19a-754c.yaml
@@ -1,0 +1,179 @@
+format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ct/statute/19a-754c
+  summary: |-
+    Section 19a-754c establishes the Covered Connecticut program within the Department of Social Services. The department provides premium and cost-sharing subsidies sufficient to ensure fully subsidized coverage for eligible enrollees: on and after July 1, 2022, all parents, needy caretaker relatives and low-income adults aged nineteen to sixty-four who are eligible for qualified-health-plan premium and cost-sharing subsidies, are ineligible for Medicaid because their income exceeds the Medicaid income limits, have household income up to one hundred seventy-five per cent of the federal poverty level, receive silver-level exchange coverage in the individual market, and utilize the full amount of applicable premium subsidies. This module encodes the premium-subsidy axis: the 175 per cent income ceiling, the adult age band, the eligibility conjunction, and the residual monthly premium subsidy that fills the enrollee's remaining silver-plan premium after federal premium subsidies to zero.
+  deferred_outputs:
+  - output: us-ct:statutes/19a-754c#covered_connecticut_cost_sharing_subsidy
+    reason: Subsection (b)(1) also requires cost-sharing subsidies sufficient to ensure
+      fully subsidized coverage, but the enrollee cost-sharing surface (deductibles,
+      copayments, coinsurance by plan) is not represented in this module's executable
+      context.
+  - output: us-ct:statutes/19a-754c#covered_connecticut_dental_and_nemt_services
+    reason: Subsection (b)(2) provides dental and nonemergency medical transportation
+      services as provided under chapter 319v; these are in-kind service benefits
+      without a monetary surface in this module.
+  - output: us-ct:statutes/19a-754c#covered_connecticut_family_member_extensions
+    reason: Subparagraphs (b)(1)(B) and (b)(1)(D) extend coverage to disabled or
+      dependent children over age twenty-six of covered parents and caretaker
+      relatives under sections 38a-489, 38a-497, 38a-512a and 38a-512b; these
+      cohort extensions require dependent-relationship facts not represented in
+      the module's TaxUnit surface.
+  - output: us-ct:statutes/19a-754c#covered_connecticut_carrier_reimbursement
+    reason: Subsection (b)(3) establishes quarterly carrier reimbursement procedures,
+      an administrative payment mechanic between the department and health carriers
+      rather than a household-level computation.
+  - output: us-ct:statutes/19a-754c#covered_connecticut_chapter_229_income_exclusion
+    reason: Subsection (d) excludes program benefits and subsidies from income for
+      chapter 229 (Connecticut income tax) purposes; the exclusion operates inside
+      the chapter 229 gross-income computation, which is outside this module.
+rules:
+- name: covered_connecticut_maximum_household_income_poverty_line_ratio
+  kind: parameter
+  dtype: Rate
+  source: Conn. Gen. Stat. § 19a-754c(b)(1)(C)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/19a-754c
+          excerpt: have household income up to one hundred seventy-five per cent of
+            the federal poverty level
+  versions:
+  - effective_from: '2021-07-01'
+    formula: |-
+      1.75
+- name: covered_connecticut_minimum_adult_age
+  kind: parameter
+  dtype: Count
+  source: Conn. Gen. Stat. § 19a-754c(b)(1)(C)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/19a-754c
+          excerpt: are at least nineteen but not more than sixty-four years of age
+  versions:
+  - effective_from: '2022-07-01'
+    formula: |-
+      19
+- name: covered_connecticut_maximum_adult_age
+  kind: parameter
+  dtype: Count
+  source: Conn. Gen. Stat. § 19a-754c(b)(1)(C)(i)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ct/statute/19a-754c
+          excerpt: are at least nineteen but not more than sixty-four years of age
+  versions:
+  - effective_from: '2022-07-01'
+    formula: |-
+      64
+- name: covered_connecticut_income_eligible
+  kind: derived
+  entity: TaxUnit
+  dtype: Boolean
+  period: Month
+  source: Conn. Gen. Stat. § 19a-754c(b)(1)(C)(iv)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/19a-754c
+          excerpt: have household income up to one hundred seventy-five per cent of
+            the federal poverty level
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:statutes/19a-754c#covered_connecticut_maximum_household_income_poverty_line_ratio
+          output: covered_connecticut_maximum_household_income_poverty_line_ratio
+          hash: sha256:local
+  versions:
+  - effective_from: '2021-07-01'
+    formula: |-
+      household_income_poverty_line_ratio <= covered_connecticut_maximum_household_income_poverty_line_ratio
+- name: covered_connecticut_adult_eligible
+  kind: derived
+  entity: TaxUnit
+  dtype: Boolean
+  period: Month
+  source: Conn. Gen. Stat. § 19a-754c(b)(1)(C)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/19a-754c
+          excerpt: for all parents, needy caretaker relatives and low-income adults
+            who (i) are at least nineteen but not more than sixty-four years of age,
+            (ii) are eligible for premium and cost-sharing subsidies for a qualified
+            health plan, (iii) are ineligible for Medicaid because their income exceeds
+            the Medicaid income limits under chapter 319v
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:statutes/19a-754c#covered_connecticut_minimum_adult_age
+          output: covered_connecticut_minimum_adult_age
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:statutes/19a-754c#covered_connecticut_maximum_adult_age
+          output: covered_connecticut_maximum_adult_age
+          hash: sha256:local
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:statutes/19a-754c#covered_connecticut_income_eligible
+          output: covered_connecticut_income_eligible
+          hash: sha256:local
+  versions:
+  - effective_from: '2022-07-01'
+    formula: |-
+      adult_age >= covered_connecticut_minimum_adult_age
+      and adult_age <= covered_connecticut_maximum_adult_age
+      and eligible_for_qualified_health_plan_premium_and_cost_sharing_subsidies
+      and ineligible_for_medicaid_because_income_exceeds_medicaid_income_limits
+      and covered_connecticut_income_eligible
+      and receiving_silver_level_exchange_individual_market_coverage
+      and utilizing_full_amount_of_applicable_premium_subsidies
+- name: covered_connecticut_monthly_premium_subsidy
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Month
+  unit: USD
+  source: Conn. Gen. Stat. § 19a-754c(b)(1)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-ct/statute/19a-754c
+          excerpt: Provide premium and cost-sharing subsidies that are sufficient
+            to ensure fully subsidized coverage
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-ct:statutes/19a-754c#covered_connecticut_adult_eligible
+          output: covered_connecticut_adult_eligible
+          hash: sha256:local
+  versions:
+  - effective_from: '2022-07-01'
+    formula: |-
+      if covered_connecticut_adult_eligible: max(0, silver_level_qualified_health_plan_monthly_premium - federal_monthly_premium_subsidy) else: 0


### PR DESCRIPTION
## Summary

Encodes **Conn. Gen. Stat. § 19a-754c** — the Covered Connecticut program's premium-subsidy axis — as `us-ct/statutes/19a-754c.yaml` with a companion test file, and adds the module to the provisions reverse index.

**Rules encoded** (all proof atoms cite `us-ct/statute/19a-754c`, registered in the paired corpus PR TheAxiomFoundation/axiom-corpus#602):
- `covered_connecticut_maximum_household_income_poverty_line_ratio` = 1.75 ((b)(1)(C)(iv) "up to one hundred seventy-five per cent of the federal poverty level")
- `covered_connecticut_minimum_adult_age` / `maximum_adult_age` = 19 / 64 ((b)(1)(C)(i), effective 2022-07-01 per P.A. 22-118)
- `covered_connecticut_income_eligible`, `covered_connecticut_adult_eligible` — the (b)(1)(C) conjunction (QHP premium/CSR subsidy eligibility, Medicaid income-ineligibility, ≤175% FPL, silver-level exchange enrollment, full APTC utilization)
- `covered_connecticut_monthly_premium_subsidy` — the (b)(1) "fully subsidized coverage" residual: `max(0, silver premium − federal premium subsidy)` when eligible

**Deferred outputs** (documented in-module): cost-sharing subsidy amounts, (b)(2) dental/NEMT, the (b)(1)(B)/(D) over-26 disabled/dependent family-member extensions, (b)(3) carrier reimbursement mechanics, and the (d) chapter 229 income exclusion.

**Tests** (8 cases): residual subsidy arithmetic, the $0 floor when federal subsidies meet/exceed the premium, the inclusive 175% boundary (1.75 eligible / 1.76 not), the 19–64 age band edges (18/65), and the silver-enrollment gate.

## Notes for review

- Hand-authored (no axiom-encode manifest) — the manifest test treats absent manifests as fine; happy to re-run through axiom-encode if that's preferred for new modules.
- Reverse index regenerated; the diff is a pure 9-line addition for the new module (hand-merged onto the committed index because a Windows working tree cannot materialize the `us-la`/`us-nj` colon-named files; verified no entries dropped).
- First of a series: the 9 state ACA premium-assistance programs recently merged in PolicyEngine-US (MD/NM/CA/CO/WA/MA/NJ/VT/CT). CT goes first as the simplest (pure residual-to-zero). PolicyEngine-US models the same program as `ct_covered_connecticut` (PolicyEngine/policyengine-us#9246), so an `axiom-oracles` comparison in the `us-aca-ptc-grid` style is the natural follow-up.
- Repo layout/shape/name/companion-test suites pass locally (the two remaining local failures are Windows artifacts: a path-separator mismatch on the pre-existing `us-ca/regulations/mpp/63-406/1.yaml` known issue, and the manifest scan over the uncheckoutable colon files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
